### PR TITLE
define and use FLUFF.Colour for Colour Cards

### DIFF
--- a/MoreFluff.lua
+++ b/MoreFluff.lua
@@ -1,3 +1,4 @@
+FLUFF = {}
 local current_mod = SMODS.current_mod
 MoreFluff = SMODS.current_mod
 


### PR DESCRIPTION
If you don't mind testing everything more thoroughly, that would be fantastic- I tested one case for each feature as well as all of the more unique standalone cards, but I haven't tested every single card and I haven't tested any of the crossmod cards defined. Also, the Cryptid crossmod Colours are all commented out so I haven't touched those.

FLUFF.Colour is a globally-available extension of SMODS.Consumable that helps cut down on repeated code when defining new Colour Cards:
- automatically handles `display_size`, `pixel_size`, and assigning the set to "Colour"
- provides a default `loc_vars` function
- automatically sets `card.ability.val` and `card.ability.partial_rounds` to 0, allowing those values to be removed from the config tables
- provides automated behavior if you set `config.suit`, `config.tag`, `config.create_set`, or `config.create_key`
- supports a custom `colour_effect` function, which behaves like the `use` function but is automatically run for as many triggers as the Colour Card had stored.
- still supports overwriting the `use` function with a custom one, if need be (e.g. the Pink and Brown cards)

When creating new Colour Cards, you still must define the following:
- key and name
- atlas and sprite position
- `config.upgrade_rounds`

## `config.suit`
If `config.suit` is set to the full key of a suit in-game (e.g. "Spades" or "paperback_Stars"), the Colour Card will automatically convert one random card in hand to the specified suit for each stored trigger.
## `config.tag`
If `config.tag` is set to the full key of a tag in-game (e.g. "tag_rare" or "tag_mf_colour"), the Colour Card will automatically spawn the specified tag once per stored trigger.
## `config.create_set`
If `config.create_set` is set to the proper name of a card set in-game (e.g. "Joker" or "Colour"), the Colour Card will automatically spawn one random Negative card from that set per stored trigger.
## `config.create_key`
If `config.create_key` is set to the full key of any card in-game (e.g. "j_mf_oopsallfives" or "c_soul"), the Colour Card will automatically spawn one Negative copy of the specified card per stored trigger.